### PR TITLE
Ensure workflow_access will work with non-integer role identifiers.

### DIFF
--- a/workflow_access/config/workflow_access.settings.json
+++ b/workflow_access/config/workflow_access.settings.json
@@ -1,4 +1,5 @@
 {
     "_config_name": "workflow_access.settings",
-    "workflow_access_priority": "0"
+    "workflow_access_priority": "0",
+    "roles_to_gids_map": {}
 }

--- a/workflow_access/workflow_access.install
+++ b/workflow_access/workflow_access.install
@@ -67,12 +67,6 @@ function workflow_access_disable() {
   node_access_needs_rebuild(TRUE);
 }
 
-// TODO The old hook_update_N functions cannot be applied to Backdrop.
-function workflow_access_update_7001() { }
-
-// TODO The old hook_update_N functions cannot be applied to Backdrop.
-function workflow_access_update_7002() { }
-
 /**
  * Implements hook_update_last_removed().
  */
@@ -134,8 +128,50 @@ function workflow_access_update_1002() {
 }
 
 /**
- * Implements hook_install().
+ * Populate the new gid column with a mapping from user roles to a unique id.
  */
-function workflow_access_install() {
-  // Dynamically generated variable data was detected.
+function workflow_access_update_1003() {
+  $config = config('workflow_access.settings');
+  $roles = user_roles();
+  $highest_gid = 0;
+  $roles_to_gids_map = [
+    WORKFLOW_ROLE_AUTHOR_RID => $highest_gid,
+  ];
+  foreach (array_keys($roles) as $name) {
+    $highest_gid++;
+    $roles_to_gids_map[$name] = $highest_gid;
+  }
+  $config->set('roles_to_gids_map', $roles_to_gids_map);
+  $config->save();
+}
+
+/**
+ * Remove the gid column from the workflow_access table.
+ */
+function workflow_access_update_1004() {
+  if (db_field_exists('workflow_access', 'gid')) {
+    db_drop_primary_key('workflow_access');
+    db_drop_index('workflow_access', 'gid');
+    db_drop_field('workflow_access', 'gid');
+    db_add_primary_key('workflow_access', array('sid', 'role'));
+  }
+}
+
+/**
+ * Ensure the anonymous and authenticated roles rids have been converted
+ * to role names.
+ */
+function workflow_access_update_1005() {
+  db_update('workflow_access')
+      ->fields(array(
+        'role' => 'anonymous',
+      ))
+      ->condition('role', 1)
+      ->execute();
+  db_update('workflow_access')
+      ->fields(array(
+        'role' => 'authenticated',
+      ))
+      ->condition('role', 2)    
+      ->execute();
 }

--- a/workflow_access/workflow_access.install
+++ b/workflow_access/workflow_access.install
@@ -17,11 +17,6 @@ function workflow_access_schema() {
         'description' => 'Primary Key: The Workflow state ID.',
         'not null' => TRUE,
       ),
-      'gid' => array(
-        'type' => 'serial',
-        'description' => 'Primary Key: The Workflow grant ID.',
-        'not null' => TRUE,
-      ),
       'role' => array(
         'type' => 'varchar',
         'length' => 64,
@@ -51,9 +46,8 @@ function workflow_access_schema() {
         'default' => 0,
       ),
     ),
-    'primary key' => array('sid', 'gid'),
+    'primary key' => array('sid', 'role'),
     'indexes' => array(
-      'gid' => array('gid'),
       'role' => array('role'),
     ),
   );

--- a/workflow_access/workflow_access.module
+++ b/workflow_access/workflow_access.module
@@ -105,14 +105,77 @@ function workflow_access_help($path, $arg) {
 }
 
 /**
+ * Create a new node grants gid for a role.
+ *
+ * @param $role
+ *   The role name.
+ * @return
+ *   The gid.
+ */
+function workflow_access_create_gid_for_role($role) {
+  $roles_to_gids_map = config_get('workflow_access.settings', 'roles_to_gids_map');
+  $highest_gid = 0;
+  foreach ($roles_to_gids_map as $gid) {
+    if ($gid > $highest_gid) {
+      $highest_gid = $gid;
+    }
+  }
+  $new_gid = $highest_gid + 1;
+  $roles_to_gids_map[$role] = $new_gid;
+  config_set('workflow_access.settings', 'roles_to_gids_map', $roles_to_gids_map);
+  return $new_gid;
+}
+
+/**
+ * Get a list of gids for the passed in roles.
+ *
+ * @param $roles
+ *   An array of role names.
+ * @return array
+ *   An array of gids keyed by the role name.
+ */
+function workflow_access_get_gids_for_roles($roles) {
+  $roles_to_gids_map = config_get('workflow_access.settings', 'roles_to_gids_map');
+  $gids_for_roles = array();
+  foreach ($roles as $role) {
+    $gids_for_roles[$role] = $roles_to_gids_map[$role];
+  }
+  return $gids_for_roles;
+}
+
+
+/**
+ * Implements hook_user_role_insert().
+ * 
+ * When a new role is created, we need to create a new gid for it.
+ */
+function workflow_access_user_role_insert($role) {
+  workflow_access_create_gid_for_role($role->name);
+}
+
+/**
+ * Implements hook_user_role_delete().
+ *
+ * When a role is deleted, we need to delete the gid and any workflow_access
+ * settings for it.
+ */
+function workflow_access_user_role_delete($role) {
+  $roles_to_gids_map = config_get('workflow_access.settings', 'roles_to_gids_map');
+  unset($roles_to_gids_map[$role->name]);
+  config_set('workflow_access.settings', 'roles_to_gids_map', $roles_to_gids_map);
+  db_delete('workflow_access')->condition('role', $role->name)->execute();
+}
+
+/**
  * Implements hook_node_grants().
  *
  * Supply the workflow access grants. We are simply using
  * roles as access lists, so roles get translates to gids.
  */
 function workflow_access_node_grants($account, $op) {
+  $account_gids = workflow_access_get_gids_for_roles($account->roles);
   return array(
-    'workflow_access' => array_keys($account->roles),
+    'workflow_access' => array_values($account_gids),
     'workflow_access_owner' => array($account->uid),
   );
 }
@@ -176,6 +239,7 @@ function workflow_access_node_access_records($node) {
   $uid = isset($node->uid) ? $node->uid : 0;
 
   $count = 0;
+  $roles_to_gids_map = config_get('workflow_access.settings', 'roles_to_gids_map');
   foreach ($node->workflow_transitions as $transition) {
     // @todo: add support for +1 workflows per entity.
     if ($count++ == 1 ) {
@@ -188,8 +252,7 @@ function workflow_access_node_access_records($node) {
     if ($current_sid = workflow_node_current_state($node, 'node', $field_name)) {
       foreach (workflow_access_get_workflow_access_by_sid($current_sid) as $grant) {
         $realm = ($uid > 0 && $grant->role == WORKFLOW_ROLE_AUTHOR_RID) ? 'workflow_access_owner' : 'workflow_access';
-        // @todo the gid has to be an integer so need to use a new gid column in table.
-        $gid = ($uid > 0 && $grant->role == WORKFLOW_ROLE_AUTHOR_RID) ? $uid : $grant->role;
+        $gid = ($uid > 0 && $grant->role == WORKFLOW_ROLE_AUTHOR_RID) ? $uid : $roles_to_gids_map[$grant->role];
 
         // Anonymous ($uid == 0) author is not allowed for role 'author' (== -1).
         // Both logically (Anonymous having more rights then authenticated)

--- a/workflow_access/workflow_access.pages.inc
+++ b/workflow_access/workflow_access.pages.inc
@@ -76,18 +76,17 @@ function workflow_access_form($form, $form_state, Workflow $workflow) {
     foreach (workflow_access_get_workflow_access_by_sid($state->sid) as $access) {
       $count++;
       if ($access->grant_view) {
-        $view[] = $access->gid;
+        $view[] = $access->role;
       }
       if ($access->grant_update) {
-        $update[] = $access->gid;
+        $update[] = $access->role;
       }
       if ($access->grant_delete) {
-        $delete[] = $access->gid;
+        $delete[] = $access->role;
       }
     }
     // Allow view grants by default for anonymous and authenticated users,
     // if no grants were set up earlier.
-    // @todo can't use role names for grant ID.
     if (!$count) {
       $view = array(BACKDROP_ANONYMOUS_ROLE, BACKDROP_AUTHENTICATED_ROLE);
     }


### PR DESCRIPTION
In Backdrop, the unique identifier for a role is now the role name. This requires some changes to how workflow_access manages node access. There was some prior work in commit 3054dea42c for this but I've taken a different approach and am instead storing a map in config between role names and gids.

Fixes #7